### PR TITLE
Removed clipboard setting in vimrc on macOS

### DIFF
--- a/macOS/.vimrc
+++ b/macOS/.vimrc
@@ -67,7 +67,9 @@ set shiftwidth=2                                             " Reindent with 2 s
 set list                                                     " Show invisible chars
 set listchars=""                                             " Reset listchars
 set list listchars=tab:»·,trail:·                            " Set listchars for tabs and trailing spaces
-set clipboard=unnamed                                        " Mac OS X Clipboard sharing
+if $TMUX == ''
+  set clipboard+=unnamed
+endif
 set splitbelow                                               " Split panes to below
 set splitright                                               " Split panes to right
 set statusline=%<%f\ %h%m%r%=\ %-14.(%l,%c%V%)\ %P%#warningmsg#%{SyntasticStatuslineFlag()}%*


### PR DESCRIPTION
Seems like the new version of vim messes up copy/pasting when you set clipboard in vimrc and use vim inside tmux..

Check:
http://stackoverflow.com/questions/11404800/fix-vim-tmux-yank-paste-on-unnamed-register/11434479